### PR TITLE
Override decimals function so it matches base token

### DIFF
--- a/contracts/ERC20R/ERC20RWrapper.sol
+++ b/contracts/ERC20R/ERC20RWrapper.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.20;
 
 import {IERC20R} from "../interfaces/IERC20R.sol";
 import {RecordsDeque, RecordsDequeLib, Record, Suspension} from "../util/RecordUtil.sol";
-import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -33,7 +33,7 @@ contract ERC20RWrapper is IERC20R, ERC20 {
         _;
     }
 
-    IERC20 internal immutable baseERC20;
+    IERC20Metadata internal immutable baseERC20;
     uint256 internal _totalSupply; // includes settled and unsettled. 
 
     /**
@@ -88,15 +88,22 @@ contract ERC20RWrapper is IERC20R, ERC20 {
     ) ERC20(name_, symbol_) {
         recoverableWindow = recoverableWindow_;
         governanceAddress = governanceAddress_;
-        baseERC20 = IERC20(baseERC20_);
+        baseERC20 = IERC20Metadata(baseERC20_);
         MAX_TO_CLEAN = maxToClean;
     }
 
     /**
-     * @inheritdoc IERC20
+     * Returns total supply.
      */
     function totalSupply() public view virtual override returns (uint256) {
         return _totalSupply;
+    }
+
+    /**
+     * @inheritdoc IERC20Metadata
+     */
+    function decimals() public view virtual override returns (uint8) {
+        return baseERC20.decimals();
     }
 
     /**

--- a/test/ERC20RWrapper.t.sol
+++ b/test/ERC20RWrapper.t.sol
@@ -77,6 +77,10 @@ contract ERC20RWrapperTest is Test {
         assertEq(rtoken.governanceAddress(), governance);
     }
 
+    function testDecimals() public {
+        assertEq(rtoken.decimals(), erc20.decimals());
+    }
+
     function _wrap(address account, uint256 amount) private {
         erc20.mint(account, amount);
         vm.startPrank(account);


### PR DESCRIPTION
The ERC20R token `decimals` value should match the underlying base token's `decimals`. 