### PR TITLE
Put restrictions on deleteAt to avoid odd edge cases

### DIFF
--- a/test/RecordsDequeLib.t.sol
+++ b/test/RecordsDequeLib.t.sol
@@ -23,6 +23,7 @@ contract RecordsTest is Test {
     error InvalidUnfreezeAmount(uint256 currentFrozenInRecord, uint256 unfreezeAmount);
     error InvalidFreezeAmount(uint256 remainingToFreeze, uint256 freezeAmount);
     error InvalidSubtractedValue(uint256 rawIndex, uint256 amount, uint256 subtractedValue);
+    error IndexZeroNotDeletable();
 
     function assertEqRecords(Record memory r1, Record memory r2) private {
         assertEq(r1.amount, r2.amount);
@@ -162,6 +163,7 @@ contract RecordsTest is Test {
         assertEqRecords(rd.getAt(rawIndex), Record(0, 0, 0, 0, 0));
         assertEq(rd.head, 1);
         assertEq(rd.tail, 1);
+        assertEq(rd.getAt(0).prev, 0);
     }
 
     function testDeleteAt_middle() public {
@@ -212,6 +214,11 @@ contract RecordsTest is Test {
         rd.deleteAt(rawIndex);
         assertEq(rd.head, 0);
         assertEq(rd.tail, 2);
+    }
+
+    function testDeleteAtZero_error() public {
+        vm.expectRevert(abi.encodeWithSelector(IndexZeroNotDeletable.selector));
+        rd.deleteAt(0);
     }
 
     function testFreezeRecord() public {


### PR DESCRIPTION
Prevent `deleteAt` from:
* deleting at index 0
* modifying the `prev` variable on the record at index 0
Also updated a comment for accuracy. 