### PR TITLE
Audit fix: disallow self transfer

### DIFF
--- a/contracts/ERC20R/ERC20RWrapper.sol
+++ b/contracts/ERC20R/ERC20RWrapper.sol
@@ -84,6 +84,7 @@ contract ERC20RWrapper is IERC20R, ERC20 {
     error CallerMustBeGovernance(address caller);
     error RecordNotFound(address account, uint256 rawIndex);
     error RecordAlreadySettled(address account, uint256 rawIndex);
+    error SelfTransferNotAllowed();
 
     constructor(
         string memory name_,
@@ -408,6 +409,12 @@ contract ERC20RWrapper is IERC20R, ERC20 {
         // there is no need to check if `from` is the zero address, because it cannot 
         // call transfer, nor would anyone have approval to spend from it. 
         _checkNotZeroAddress(to);
+
+        // Transfering to self should not be allowed, would add confusing UX 
+        if (to == from) {
+            revert SelfTransferNotAllowed();
+        }
+
         _clean(from);
         _clean(to);
         uint256 unsettledUsed = 0;

--- a/test/rpool/RPoolOrderBook.t.sol
+++ b/test/rpool/RPoolOrderBook.t.sol
@@ -24,6 +24,7 @@ contract RPoolOrderBookTest is Test {
     RPoolOrderBook private rpob;
     address alice = makeAddr('alice');
     address bob = makeAddr('bob');
+    address temp = makeAddr("temp");
     uint256 private constant HALF_DAY = SECONDS_PER_DAY / 2;
 
     struct BidInfo {
@@ -60,8 +61,8 @@ contract RPoolOrderBookTest is Test {
     event BidCancelled(bytes32 bidID);
 
     function _wrapUnsettle(address account, uint256 amount) private {
-        erc20.mint(account, amount);
-        vm.startPrank(account);
+        erc20.mint(temp, amount);
+        vm.startPrank(temp);
         erc20.approve(address(rtoken), amount);
         rtoken.wrap(amount);
         rtoken.transfer(account, amount);


### PR DESCRIPTION
Disallows transfering to self, to avoid UX confusion. See audit report for more details. 